### PR TITLE
Add function to decode more than one data structure in a file

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -23,7 +23,7 @@ from struct import pack
 from collections import OrderedDict
 
 from ubjson import (dump as ubjdump, dumpb as ubjdumpb, load as ubjload, loadb as ubjloadb, EncoderException,
-                    DecoderException)
+                    DecoderException, load_all as ubjload_all)
 from ubjson.markers import (TYPE_NULL, TYPE_NOOP, TYPE_BOOL_TRUE, TYPE_BOOL_FALSE, TYPE_INT8, TYPE_UINT8, TYPE_INT16,
                             TYPE_INT32, TYPE_INT64, TYPE_FLOAT32, TYPE_FLOAT64, TYPE_HIGH_PREC, TYPE_CHAR, TYPE_STRING,
                             OBJECT_START, OBJECT_END, ARRAY_START, ARRAY_END, CONTAINER_TYPE, CONTAINER_COUNT)
@@ -492,6 +492,35 @@ class TestEncodeDecodePlain(TestCase):  # pylint: disable=too-many-public-method
             return obj
 
         self.check_enc_dec({'a': 1, 'b': {2, 3, 4}}, object_hook=object_hook, default=default)
+
+    def test_load_all(self):
+        test_data = [
+            {
+                "an int": 1234,
+                "a float": 1.234,
+                "some text": "Hello World!"
+            },
+            {
+                "an array of text!": [
+                    "abc",
+                    "def"
+                ],
+                "A very large number": 123456789101112
+            }
+        ]
+
+        with open("ubj_multi_object_test.ubj", "wb") as f:
+            for item in test_data:
+                f.write(ubjdumpb(item))
+                curr_file_pos = f.tell()
+                f.seek(curr_file_pos + 200)
+                f.write(b'\x00')
+
+        with open("ubj_multi_object_test.ubj", "rb") as f:
+            output = ubjload_all(f)
+
+        self.assertEqual(test_data, output)
+
 
 
 class TestEncodeDecodeFp(TestEncodeDecodePlain):

--- a/ubjson/__init__.py
+++ b/ubjson/__init__.py
@@ -31,12 +31,12 @@ try:
     EXTENSION_ENABLED = True  # pragma: no cover
 except ImportError:
     from .encoder import dump, dumpb
-    from .decoder import load, loadb
+    from .decoder import load, loadb, load_all
     EXTENSION_ENABLED = False
 
 from .encoder import EncoderException  # noqa
-from .decoder import DecoderException  # noqa
+from .decoder import DecoderException, load_all  # noqa
 
 __version__ = '0.12.0'
 
-__all__ = ('EXTENSION_ENABLED', 'dump', 'dumpb', 'EncoderException', 'load', 'loadb', 'DecoderException')
+__all__ = ('EXTENSION_ENABLED', 'dump', 'dumpb', 'EncoderException', 'load', 'loadb', 'DecoderException', 'load_all')


### PR DESCRIPTION
I needed to decode binary files with many ubjson structures inside possibly separated by null characters, I created a function called `load_all` to handle this case. My code is PEP8 compliant and includes some testing, though it could use a little more to get to 100% coverage.