### PR TITLE
Fix decoding from file-like object reading too much data (#9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 __pycache__/
 build/
 dist/
-htmlcov/
 ubjson/*.html
 *.py[cod]
 *.so
 .coverage
+coverage
 MANIFEST
 *.egg
 .eggs/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 UNRELEASED
 - Fix DecoderException not including offset when C-extension in use, expose
   property for it.
+- Fix decoding via C extension reading too much data from file-like objects
+- Test suite exercises both pure & extension modules when extension enabled
+- Fix spelling errors in cli util (hoenn)
 
 0.13.0
 - Make extension build more reproducible with sorted sources (bmwiedemann)

--- a/coverage_test.sh
+++ b/coverage_test.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 
-# coverage currently only measured without extension, so clean out first
-git clean -fXd ubjson
-python3 -mcoverage run --omit=ubjson/compat.py -m unittest discover test/ -v
-python3 -mcoverage html
-echo -e "\nFor coverage results see htmlcov/index.html\n"
+# Requirements
+# ------------
+# Python: coverage
+# C: Gcov (GCC), lcov
+
+git clean -fdX build/ _ubjson*.so
+
+# Coverage should be measured with extension compiled for both Python 2 & 3 (e.g. via venv)
+export CFLAGS="-coverage"
+python setup.py build_ext -i
+python -mcoverage run --branch --omit=ubjson/compat.py -m unittest discover test/ -v
+python -mcoverage html -d coverage/python
+lcov --capture --directory . --output-file /tmp/ubjson-coverage.info
+genhtml /tmp/ubjson-coverage.info --output-directory coverage/c
+echo -e "\nFor coverage results see index.html in coverage sub-directories.\n"

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -108,16 +108,17 @@ _ubjson_encoder_buffer_t* _ubjson_encoder_buffer_create(_ubjson_encoder_prefs_t*
     return buffer;
 
 bail:
-    _ubjson_encoder_buffer_free(buffer);
+    _ubjson_encoder_buffer_free(&buffer);
     return NULL;
 }
 
-void _ubjson_encoder_buffer_free(_ubjson_encoder_buffer_t *buffer) {
-    if (NULL != buffer) {
-        Py_XDECREF(buffer->obj);
-        Py_XDECREF(buffer->fp_write);
-        Py_XDECREF(buffer->markers);
-        free(buffer);
+void _ubjson_encoder_buffer_free(_ubjson_encoder_buffer_t **buffer) {
+    if (NULL != buffer && NULL != *buffer) {
+        Py_XDECREF((*buffer)->obj);
+        Py_XDECREF((*buffer)->fp_write);
+        Py_XDECREF((*buffer)->markers);
+        free(*buffer);
+        *buffer = NULL;
     }
 }
 

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -48,7 +48,7 @@ typedef struct {
 /******************************************************************************/
 
 extern _ubjson_encoder_buffer_t* _ubjson_encoder_buffer_create(_ubjson_encoder_prefs_t* prefs, PyObject *fp_write);
-extern void _ubjson_encoder_buffer_free(_ubjson_encoder_buffer_t *buffer);
+extern void _ubjson_encoder_buffer_free(_ubjson_encoder_buffer_t **buffer);
 extern PyObject* _ubjson_encoder_buffer_finalise(_ubjson_encoder_buffer_t *buffer);
 extern int _ubjson_encode_value(PyObject *obj, _ubjson_encoder_buffer_t *buffer);
 extern int _ubjson_encoder_init(void);

--- a/ubjson/__init__.py
+++ b/ubjson/__init__.py
@@ -28,8 +28,8 @@ To use a file-like object as input/output, use dump() & load() methods instead.
 
 try:
     from _ubjson import dump, dumpb, load, loadb
-    EXTENSION_ENABLED = True  # pragma: no cover
-except ImportError:
+    EXTENSION_ENABLED = True
+except ImportError:  # pragma: no cover
     from .encoder import dump, dumpb
     from .decoder import load, loadb
     EXTENSION_ENABLED = False


### PR DESCRIPTION
## Changes
- Decoder uses buffer if seeking possible, minimal reads otherwise
- Encoder/decoder buffers now unset/NULL after freeing (ext)
- Added test cases for successful and failing post-decode seek calls (ext)

## Testing
### Versions
- Python 3.6.7 64-bit (Ubuntu 18.04, macOS 10.14.4)
- Python 2.7.15 64-bit (Ubuntu 18.04)
- Python 3.7.3 64-bit (Windows 10)

### What
- C-extenions builds (with/without extra GCC flags as per `setup.py` where applicable)
- Unit tests in pure Python & C-extension
  - suite now exercises both in one run
  - additional tests to cover this issue
- Reference leak testing [using](https://github.com/Iotic-Labs/py-ubjson/blob/a4216fc7be4ce4471e5c1c4b40bc2595d4fec853/test/test.py#L685-L702) `pympler`
- Performance tests as per #9
- [Coverage tests](https://github.com/Iotic-Labs/py-ubjson/blob/a4216fc7be4ce4471e5c1c4b40bc2595d4fec853/coverage_test.sh) (including for C extension)
