### PR TITLE
Fix decimal encoding bug (#12)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,8 +90,12 @@ setup(
         ]
     },
     zip_safe=False,
-    ext_modules=([Extension('_ubjson', sorted(glob('src/*.c')), extra_compile_args=COMPILE_ARGS)]
-                 if BUILD_EXTENSIONS else []),
+    ext_modules=([Extension(
+        '_ubjson',
+        sorted(glob('src/*.c')),
+        extra_compile_args=COMPILE_ARGS,
+        # undef_macros=['NDEBUG']
+    )] if BUILD_EXTENSIONS else []),
     cmdclass={"build_ext": BuildExtWarnOnFail},
     keywords=['ubjson', 'ubj'],
     classifiers=[
@@ -107,6 +111,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -268,7 +268,7 @@ static int _encode_PyDecimal(PyObject *obj, _ubjson_encoder_buffer_t *buffer) {
 #endif
         BAIL_ON_NULL(encoded = PyUnicode_AsEncodedString(str, "utf-8", NULL));
         raw = PyBytes_AS_STRING(encoded);
-        len = PyBytes_GET_SIZE(str);
+        len = PyBytes_GET_SIZE(encoded);
 
         WRITE_CHAR_OR_BAIL(TYPE_HIGH_PREC);
         BAIL_ON_NONZERO(_encode_longlong(len, buffer));


### PR DESCRIPTION
- Use length from raw encoded string, not unicode version
- Also include Python 3.8 in classifiers (now that tested against)

### Notes for reviewing
- [The change](https://github.com/Iotic-Labs/py-ubjson/blob/ec7827a12902214bcdaada30dfccd338cda89f0b/src/encoder.c#L271) switches from incorrectly attempting to determine length of a str/unicode object  (`str`) to the actual `bytes` object (`encoded`), or in other words what should be happening is:
    1. Convert `Decimal` to its string representation (`obj` => `str`)
    2. Encode the string as utf-8 (`str` => `encoded`)
    3. Write the encoded version into the output buffer (`encoded` => `buffer`)
- To trigger the assert/crash (as reported in #12):
    1. Uncomment the `undef_macros` line in `setup.py`
    2. Undo the fix in `encoder.c`
    3. Run e.g. (in venv, for specific Python version such as 3.8):
- gdb/pdb output is not very informative here because `PyBytes_Check` is a macro so the backtrace  does not confirm the type of input for the macro itself, just the line (which is clear from the asset anyway).
```shell
python setup.py build_ext -ig
python -m unittest discover test/ -v
```