### PR TITLE
Transition to pyproject.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "py-ubjson"
+dynamic = ["version"]
+description="Universal Binary JSON encoder/decoder."
+readme = { file = "README.md", content-type = "text/markdown" }
+authors = [
+    { name = "Iotic Labs Ltd", email = "info@iotic-labs.com" }
+]
+maintainers = [
+    { name = "Iotic Labs Ltd", email = "vilnis.termanis@iotic-labs.com" }
+]
+license = { text = "Apache-2.0" }
+keywords = ["ubjson", "ubj"]
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'License :: OSI Approved :: Apache Software License',
+    'Intended Audience :: Developers',
+    'Programming Language :: C',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.2',
+    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Topic :: Software Development :: Libraries',
+    'Topic :: Software Development :: Libraries :: Python Modules'
+]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+# Used in combination of the MANIFEST.in to exclude these two directories from the binary
+# wheel.
+exclude = ["src", "test"]
+
+[tool.setuptools.dynamic]
+version = { attr = "ubjson.__version__" }
+
+[project.urls]
+repository = "https://github.com/Iotic-Labs/py-ubjson"
+
+[project.optional-dependencies]
+dev = ["Pympler>=0.7,<0.8", "coverage>=4.5.3,<4.6"]

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,6 @@ from distutils.command.build_ext import build_ext
 from distutils.errors import CCompilerError
 from distutils.errors import DistutilsPlatformError, DistutilsExecError
 
-from ubjson import __version__ as version
-
 
 def load_description(filename):
     script_dir = os.path.abspath(os.path.dirname(__file__))
@@ -72,24 +70,6 @@ COMPILE_ARGS = ['-std=c99']
 #                  '-pedantic']
 
 setup(
-    name='py-ubjson',
-    version=version,
-    description='Universal Binary JSON encoder/decoder',
-    long_description=load_description('README.md'),
-    long_description_content_type='text/markdown',
-    author='Iotic Labs Ltd',
-    author_email='info@iotic-labs.com',
-    maintainer='Iotic Labs Ltd',
-    maintainer_email='vilnis.termanis@iotic-labs.com',
-    url='https://github.com/Iotic-Labs/py-ubjson',
-    license='Apache License 2.0',
-    packages=['ubjson'],
-    extras_require={
-        'dev': [
-            'Pympler>=0.7 ,<0.8',
-            'coverage>=4.5.3,<4.6'
-        ]
-    },
     zip_safe=False,
     ext_modules=([Extension(
         '_ubjson',
@@ -98,22 +78,4 @@ setup(
         # undef_macros=['NDEBUG']
     )] if BUILD_EXTENSIONS else []),
     cmdclass={"build_ext": BuildExtWarnOnFail},
-    keywords=['ubjson', 'ubj'],
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: Apache Software License',
-        'Intended Audience :: Developers',
-        'Programming Language :: C',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
 )


### PR DESCRIPTION
Hi, this PR adds support for packaging py-ubjson with `pyproject.toml`. Please see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/ for details about pyproject.

- `setuptools` continues to be used as the build backend.
- Tested with sdist and binary wheel.

We are running into an issue with installing py-ubjson due to missing setuptools in isolated environments. Using pyproject can help direct the build tool like pip to install setuptools. Besides, pyproject is considered to be the standard Python packaging method now.

py3.12 is not listed in the classifier due to https://github.com/Iotic-Labs/py-ubjson/pull/19 .