### PR TITLE
Allow decoding files with invalid utf-8

### DIFF
--- a/src/_ubjson.c
+++ b/src/_ubjson.c
@@ -26,7 +26,7 @@
 static _ubjson_encoder_prefs_t _ubjson_encoder_prefs_defaults = { NULL, 0, 0, 1 };
 
 // no_bytes, object_pairs_hook
-static _ubjson_decoder_prefs_t _ubjson_decoder_prefs_defaults = { NULL, NULL, 0, 0 };
+static _ubjson_decoder_prefs_t _ubjson_decoder_prefs_defaults = { NULL, NULL, 0, 0, NULL };
 
 /******************************************************************************/
 
@@ -98,8 +98,8 @@ PyDoc_STRVAR(_ubjson_load__doc__, "See pure Python version (encoder.load) for do
 #define FUNC_DEF_LOAD {"load", (PyCFunction)_ubjson_load, METH_VARARGS | METH_KEYWORDS, _ubjson_load__doc__}
 static PyObject*
 _ubjson_load(PyObject *self, PyObject *args, PyObject *kwargs) {
-    static const char *format = "O|iOOi:load";
-    static char *keywords[] = {"fp", "no_bytes", "object_hook", "object_pairs_hook", "intern_object_keys", NULL};
+    static const char *format = "O|iOOiz:load";
+    static char *keywords[] = {"fp", "no_bytes", "object_hook", "object_pairs_hook", "intern_object_keys", "errors", NULL};
 
     _ubjson_decoder_buffer_t *buffer = NULL;
     _ubjson_decoder_prefs_t prefs = _ubjson_decoder_prefs_defaults;
@@ -111,7 +111,7 @@ _ubjson_load(PyObject *self, PyObject *args, PyObject *kwargs) {
     UNUSED(self);
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, format, keywords, &fp, &prefs.no_bytes,  &prefs.object_hook,
-                                     &prefs.object_pairs_hook, &prefs.intern_object_keys)) {
+                                     &prefs.object_pairs_hook, &prefs.intern_object_keys, &prefs.errors)) {
         goto bail;
     }
 
@@ -153,8 +153,8 @@ PyDoc_STRVAR(_ubjson_loadb__doc__, "See pure Python version (encoder.loadb) for 
 #define FUNC_DEF_LOADB {"loadb", (PyCFunction)_ubjson_loadb, METH_VARARGS | METH_KEYWORDS, _ubjson_loadb__doc__}
 static PyObject*
 _ubjson_loadb(PyObject *self, PyObject *args, PyObject *kwargs) {
-    static const char *format = "O|iOOi:loadb";
-    static char *keywords[] = {"chars", "no_bytes", "object_hook", "object_pairs_hook", "intern_object_keys", NULL};
+    static const char *format = "O|iOOiz:loadb";
+    static char *keywords[] = {"chars", "no_bytes", "object_hook", "object_pairs_hook", "intern_object_keys", "errors", NULL};
 
     _ubjson_decoder_buffer_t *buffer = NULL;
     _ubjson_decoder_prefs_t prefs = _ubjson_decoder_prefs_defaults;
@@ -163,7 +163,7 @@ _ubjson_loadb(PyObject *self, PyObject *args, PyObject *kwargs) {
     UNUSED(self);
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, format, keywords, &chars, &prefs.no_bytes, &prefs.object_hook,
-                                     &prefs.object_pairs_hook, &prefs.intern_object_keys)) {
+                                     &prefs.object_pairs_hook, &prefs.intern_object_keys, &prefs.errors)) {
         goto bail;
     }
     if (PyUnicode_Check(chars)) {

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -85,8 +85,8 @@
     dst_char = tmp[0];\
 }
 
-#define DECODE_UNICODE_OR_BAIL(dst_obj, raw, length, item_str) {\
-    if (NULL == ((dst_obj) = PyUnicode_FromStringAndSize(raw, length))) {\
+#define DECODE_UNICODE_OR_BAIL(dst_obj, raw, length, item_str, errors) {\
+    if (NULL == ((dst_obj) = PyUnicode_DecodeUTF8(raw, length, errors))) {\
         RAISE_DECODER_EXCEPTION(("Failed to decode utf8: " item_str));\
     }\
 }\
@@ -567,7 +567,7 @@ static PyObject* _decode_high_prec(_ubjson_decoder_buffer_t *buffer) {
     DECODE_LENGTH_OR_BAIL(length);
     READ_OR_BAIL((Py_ssize_t)length, raw, "highprec");
 
-    DECODE_UNICODE_OR_BAIL(num_str, raw, (Py_ssize_t)length, "highprec");
+    DECODE_UNICODE_OR_BAIL(num_str, raw, (Py_ssize_t)length, "highprec", buffer->prefs.errors);
 
     BAIL_ON_NULL(decimal = PyObject_CallFunctionObjArgs((PyObject*)PyDec_Type, num_str, NULL));
     Py_XDECREF(num_str);
@@ -583,7 +583,7 @@ static PyObject* _decode_char(_ubjson_decoder_buffer_t *buffer) {
     PyObject *obj = NULL;
 
     READ_CHAR_OR_BAIL(value, "char");
-    DECODE_UNICODE_OR_BAIL(obj, &value, 1, "char");
+    DECODE_UNICODE_OR_BAIL(obj, &value, 1, "char", buffer->prefs.errors);
     return obj;
 
 bail:
@@ -600,7 +600,7 @@ static PyObject* _decode_string(_ubjson_decoder_buffer_t *buffer) {
 
     if (length > 0) {
         READ_OR_BAIL((Py_ssize_t)length, raw, "string");
-        DECODE_UNICODE_OR_BAIL(obj, raw, (Py_ssize_t)length, "string");
+        DECODE_UNICODE_OR_BAIL(obj, raw, (Py_ssize_t)length, "string", buffer->prefs.errors);
     } else {
         BAIL_ON_NULL(obj = PyUnicode_FromStringAndSize(NULL, 0));
     }

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -30,6 +30,7 @@ typedef struct {
     // don't convert UINT8 arrays to bytes instances (and keep as an array of individual integers)
     int no_bytes;
     int intern_object_keys;
+    char *errors;
 } _ubjson_decoder_prefs_t;
 
 typedef struct _ubjson_decoder_buffer_t {

--- a/test/test.py
+++ b/test/test.py
@@ -134,6 +134,10 @@ class TestEncodeDecodePlain(TestCase):  # pylint: disable=too-many-public-method
         for suffix in (b'', b'\xfe'):
             with self.assertRaises(DecoderException):
                 self.ubjloadb(TYPE_CHAR + suffix)
+        # char invalid utf-8
+        for suffix in (b'\xfe',):
+            encoded = self.ubjloadb(TYPE_CHAR + suffix, errors='replace')
+            self.assertEqual(encoded, suffix.decode('utf-8', errors='replace'))
         for char in (u('a'), u('\0'), u('~')):
             self.check_enc_dec(char, 2)
 
@@ -144,6 +148,11 @@ class TestEncodeDecodePlain(TestCase):  # pylint: disable=too-many-public-method
         for suffix in (b'\x81', b'\x01', b'\x01' + b'\xfe'):
             with self.assertRaises(DecoderException):
                 self.ubjloadb(TYPE_STRING + TYPE_INT8 + suffix)
+        # string invalid utf-8
+        for length, suffix in ((b'\x01', b'\xfe'),):
+            suffix_d = suffix.decode('utf-8', errors='replace')
+            encoded = self.ubjloadb(TYPE_STRING + TYPE_INT8 + length + suffix, errors='replace')
+            self.assertEqual(encoded, suffix_d)
         # Note: In Python 2 plain str type is encoded as byte array
         for string in ('some ascii', u(r'\u00a9 with extended\u2122'), u('long string') * 100):
             self.check_enc_dec(string, 4, length_greater_or_equal=True)

--- a/test/test.py
+++ b/test/test.py
@@ -463,24 +463,24 @@ class TestEncodeDecodePlain(TestCase):  # pylint: disable=too-many-public-method
         # pylint: disable=deprecated-method,no-member
         return (self.assertRaisesRegexp if PY2 else self.assertRaisesRegex)(*args, **kwargs)
 
-    def test_recursion(self):
-        old_limit = getrecursionlimit()
-        setrecursionlimit(200)
-        try:
-            obj = current = []
-            for _ in range(getrecursionlimit() * 2):
-                new_list = []
-                current.append(new_list)
-                current = new_list
+    #def test_recursion(self):
+    #    old_limit = getrecursionlimit()
+    #    setrecursionlimit(200)
+    #    try:
+    #        obj = current = []
+    #        for _ in range(getrecursionlimit() * 2):
+    #            new_list = []
+    #            current.append(new_list)
+    #            current = new_list
 
-            with self.assert_raises_regex(RuntimeError, 'recursion'):
-                self.ubjdumpb(obj)
+    #        with self.assert_raises_regex(RuntimeError, 'recursion'):
+    #            self.ubjdumpb(obj)
 
-            raw = ARRAY_START * (getrecursionlimit() * 2)
-            with self.assert_raises_regex(RuntimeError, 'recursion'):
-                self.ubjloadb(raw)
-        finally:
-            setrecursionlimit(old_limit)
+    #        raw = ARRAY_START * (getrecursionlimit() * 2)
+    #        with self.assert_raises_regex(RuntimeError, 'recursion'):
+    #            self.ubjloadb(raw)
+    #    finally:
+    #        setrecursionlimit(old_limit)
 
     def test_encode_default(self):
         def default(obj):

--- a/test/test.py
+++ b/test/test.py
@@ -472,24 +472,24 @@ class TestEncodeDecodePlain(TestCase):  # pylint: disable=too-many-public-method
         # pylint: disable=deprecated-method,no-member
         return (self.assertRaisesRegexp if PY2 else self.assertRaisesRegex)(*args, **kwargs)
 
-    #def test_recursion(self):
-    #    old_limit = getrecursionlimit()
-    #    setrecursionlimit(200)
-    #    try:
-    #        obj = current = []
-    #        for _ in range(getrecursionlimit() * 2):
-    #            new_list = []
-    #            current.append(new_list)
-    #            current = new_list
+    def test_recursion(self):
+        old_limit = getrecursionlimit()
+        setrecursionlimit(200)
+        try:
+            obj = current = []
+            for _ in range(getrecursionlimit() * 2):
+                new_list = []
+                current.append(new_list)
+                current = new_list
 
-    #        with self.assert_raises_regex(RuntimeError, 'recursion'):
-    #            self.ubjdumpb(obj)
+            with self.assert_raises_regex(RuntimeError, 'recursion'):
+                self.ubjdumpb(obj)
 
-    #        raw = ARRAY_START * (getrecursionlimit() * 2)
-    #        with self.assert_raises_regex(RuntimeError, 'recursion'):
-    #            self.ubjloadb(raw)
-    #    finally:
-    #        setrecursionlimit(old_limit)
+            raw = ARRAY_START * (getrecursionlimit() * 2)
+            with self.assert_raises_regex(RuntimeError, 'recursion'):
+                self.ubjloadb(raw)
+        finally:
+            setrecursionlimit(old_limit)
 
     def test_encode_default(self):
         def default(obj):

--- a/ubjson/__init__.py
+++ b/ubjson/__init__.py
@@ -37,6 +37,6 @@ except ImportError:  # pragma: no cover
 from .encoder import EncoderException
 from .decoder import DecoderException
 
-__version__ = '0.16.1'
+__version__ = '0.16.2'
 
 __all__ = ('EXTENSION_ENABLED', 'dump', 'dumpb', 'EncoderException', 'load', 'loadb', 'DecoderException')

--- a/ubjson/decoder.py
+++ b/ubjson/decoder.py
@@ -56,115 +56,119 @@ class DecoderException(ValueError):
         return self.args[1]  # pylint: disable=unsubscriptable-object
 
 
+def __parse_utf8(raw, errors):
+    return raw.decode('utf-8', errors=errors)
+
+
 # pylint: disable=unused-argument
-def __decode_high_prec(fp_read, marker):
-    length = __decode_int_non_negative(fp_read, fp_read(1))
+def __decode_high_prec(fp_read, marker, errors):
+    length = __decode_int_non_negative(fp_read, fp_read(1), errors)
     raw = fp_read(length)
     if len(raw) < length:
         raise DecoderException('High prec. too short')
     try:
-        return Decimal(raw.decode('utf-8'))
+        return Decimal(__parse_utf8(raw, errors))
     except UnicodeError as ex:
         raise_from(DecoderException('Failed to decode decimal string'), ex)
     except DecimalException as ex:
         raise_from(DecoderException('Failed to decode decimal'), ex)
 
 
-def __decode_int_non_negative(fp_read, marker):
+def __decode_int_non_negative(fp_read, marker, errors):
     if marker not in __TYPES_INT:
         raise DecoderException('Integer marker expected')
-    value = __METHOD_MAP[marker](fp_read, marker)
+    value = __METHOD_MAP[marker](fp_read, marker, errors)
     if value < 0:
         raise DecoderException('Negative count/length unexpected')
     return value
 
 
-def __decode_int8(fp_read, marker):
+def __decode_int8(fp_read, marker, _errors):
     try:
         return __SMALL_INTS_DECODED[fp_read(1)]
     except KeyError as ex:
         raise_from(DecoderException('Failed to unpack int8'), ex)
 
 
-def __decode_uint8(fp_read, marker):
+def __decode_uint8(fp_read, marker, _errors):
     try:
         return __SMALL_UINTS_DECODED[fp_read(1)]
     except KeyError as ex:
         raise_from(DecoderException('Failed to unpack uint8'), ex)
 
 
-def __decode_int16(fp_read, marker):
+def __decode_int16(fp_read, marker, _errors):
     try:
         return __UNPACK_INT16(fp_read(2))[0]
     except StructError as ex:
         raise_from(DecoderException('Failed to unpack int16'), ex)
 
 
-def __decode_int32(fp_read, marker):
+def __decode_int32(fp_read, marker, _errors):
     try:
         return __UNPACK_INT32(fp_read(4))[0]
     except StructError as ex:
         raise_from(DecoderException('Failed to unpack int32'), ex)
 
 
-def __decode_int64(fp_read, marker):
+def __decode_int64(fp_read, marker, _errors):
     try:
         return __UNPACK_INT64(fp_read(8))[0]
     except StructError as ex:
         raise_from(DecoderException('Failed to unpack int64'), ex)
 
 
-def __decode_float32(fp_read, marker):
+def __decode_float32(fp_read, marker, _errors):
     try:
         return __UNPACK_FLOAT32(fp_read(4))[0]
     except StructError as ex:
         raise_from(DecoderException('Failed to unpack float32'), ex)
 
 
-def __decode_float64(fp_read, marker):
+def __decode_float64(fp_read, marker, _errors):
     try:
         return __UNPACK_FLOAT64(fp_read(8))[0]
     except StructError as ex:
         raise_from(DecoderException('Failed to unpack float64'), ex)
 
 
-def __decode_char(fp_read, marker):
+def __decode_char(fp_read, marker, errors):
     raw = fp_read(1)
     if not raw:
         raise DecoderException('Char missing')
     try:
-        return raw.decode('utf-8')
+        return __parse_utf8(raw, errors)
     except UnicodeError as ex:
         raise_from(DecoderException('Failed to decode char'), ex)
 
 
-def __decode_string(fp_read, marker):
+def __decode_string(fp_read, marker, errors):
     # current marker is string identifier, so read next byte which identifies integer type
-    length = __decode_int_non_negative(fp_read, fp_read(1))
+    length = __decode_int_non_negative(fp_read, fp_read(1), errors)
     raw = fp_read(length)
     if len(raw) < length:
         raise DecoderException('String too short')
     try:
-        return raw.decode('utf-8')
+        return __parse_utf8(raw, errors)
     except UnicodeError as ex:
         raise_from(DecoderException('Failed to decode string'), ex)
 
 
 # same as string, except there is no 'S' marker
-def __decode_object_key(fp_read, marker, intern_object_keys):
-    length = __decode_int_non_negative(fp_read, marker)
+def __decode_object_key(fp_read, marker, intern_object_keys, errors):
+    length = __decode_int_non_negative(fp_read, marker, errors)
     raw = fp_read(length)
     if len(raw) < length:
         raise DecoderException('String too short')
     try:
-        return intern_unicode(raw.decode('utf-8')) if intern_object_keys else raw.decode('utf-8')
+        return intern_unicode(__parse_utf8(raw, errors)) if intern_object_keys else __parse_utf8(raw, errors)
     except UnicodeError as ex:
         raise_from(DecoderException('Failed to decode object key'), ex)
 
 
-__METHOD_MAP = {TYPE_NULL: (lambda _, __: None),
-                TYPE_BOOL_TRUE: (lambda _, __: True),
-                TYPE_BOOL_FALSE: (lambda _, __: False),
+__METHOD_MAP = {TYPE_NULL: (lambda _, __, ___: None),
+                TYPE_BOOL_TRUE: (lambda _, __, ___: True),
+                TYPE_BOOL_FALSE: (lambda _, __, ___: False),
                 TYPE_INT8: __decode_int8,
                 TYPE_UINT8: __decode_uint8,
                 TYPE_INT16: __decode_int16,
@@ -177,7 +181,7 @@ __METHOD_MAP = {TYPE_NULL: (lambda _, __: None),
                 TYPE_STRING: __decode_string}
 
 
-def __get_container_params(fp_read, in_mapping, no_bytes):
+def __get_container_params(fp_read, in_mapping, no_bytes, errors):
     marker = fp_read(1)
     if marker == CONTAINER_TYPE:
         marker = fp_read(1)
@@ -188,7 +192,7 @@ def __get_container_params(fp_read, in_mapping, no_bytes):
     else:
         type_ = TYPE_NONE
     if marker == CONTAINER_COUNT:
-        count = __decode_int_non_negative(fp_read, fp_read(1))
+        count = __decode_int_non_negative(fp_read, fp_read(1), errors)
         counting = True
 
         # special cases (no data (None or bool) / bytes array) will be handled in calling functions
@@ -207,21 +211,21 @@ def __get_container_params(fp_read, in_mapping, no_bytes):
 
 
 def __decode_object(fp_read, no_bytes, object_hook, object_pairs_hook,  # pylint: disable=too-many-branches
-                    intern_object_keys):
-    marker, counting, count, type_ = __get_container_params(fp_read, True, no_bytes)
+                    intern_object_keys, errors):
+    marker, counting, count, type_ = __get_container_params(fp_read, True, no_bytes, errors)
     has_pairs_hook = object_pairs_hook is not None
     obj = [] if has_pairs_hook else {}
 
     # special case - no data (None or bool)
     if type_ in __TYPES_NO_DATA:
-        value = __METHOD_MAP[type_](fp_read, type_)
+        value = __METHOD_MAP[type_](fp_read, type_, errors)
         if has_pairs_hook:
             for _ in range(count):
-                obj.append((__decode_object_key(fp_read, fp_read(1), intern_object_keys), value))
+                obj.append((__decode_object_key(fp_read, fp_read(1), intern_object_keys, errors), value))
             return object_pairs_hook(obj)
 
         for _ in range(count):
-            obj[__decode_object_key(fp_read, fp_read(1), intern_object_keys)] = value
+            obj[__decode_object_key(fp_read, fp_read(1), intern_object_keys, errors)] = value
         return object_hook(obj)
 
     while count > 0 and (counting or marker != OBJECT_END):
@@ -230,12 +234,12 @@ def __decode_object(fp_read, no_bytes, object_hook, object_pairs_hook,  # pylint
             continue
 
         # decode key for object
-        key = __decode_object_key(fp_read, marker, intern_object_keys)
+        key = __decode_object_key(fp_read, marker, intern_object_keys, errors)
         marker = fp_read(1) if type_ == TYPE_NONE else type_
 
         # decode value
         try:
-            value = __METHOD_MAP[marker](fp_read, marker)
+            value = __METHOD_MAP[marker](fp_read, marker, errors)
         except KeyError:
             handled = False
         else:
@@ -244,9 +248,9 @@ def __decode_object(fp_read, no_bytes, object_hook, object_pairs_hook,  # pylint
         # handle outside above except (on KeyError) so do not have unfriendly "exception within except" backtrace
         if not handled:
             if marker == ARRAY_START:
-                value = __decode_array(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys)
+                value = __decode_array(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys, errors)
             elif marker == OBJECT_START:
-                value = __decode_object(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys)
+                value = __decode_object(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys, errors)
             else:
                 raise DecoderException('Invalid marker within object')
 
@@ -262,12 +266,12 @@ def __decode_object(fp_read, no_bytes, object_hook, object_pairs_hook,  # pylint
     return object_pairs_hook(obj) if has_pairs_hook else object_hook(obj)
 
 
-def __decode_array(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys):
-    marker, counting, count, type_ = __get_container_params(fp_read, False, no_bytes)
+def __decode_array(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys, errors):
+    marker, counting, count, type_ = __get_container_params(fp_read, False, no_bytes, errors)
 
     # special case - no data (None or bool)
     if type_ in __TYPES_NO_DATA:
-        return [__METHOD_MAP[type_](fp_read, type_)] * count
+        return [__METHOD_MAP[type_](fp_read, type_, errors)] * count
 
     # special case - bytes array
     if type_ == TYPE_UINT8 and not no_bytes:
@@ -284,7 +288,7 @@ def __decode_array(fp_read, no_bytes, object_hook, object_pairs_hook, intern_obj
 
         # decode value
         try:
-            value = __METHOD_MAP[marker](fp_read, marker)
+            value = __METHOD_MAP[marker](fp_read, marker, errors)
         except KeyError:
             handled = False
         else:
@@ -293,9 +297,9 @@ def __decode_array(fp_read, no_bytes, object_hook, object_pairs_hook, intern_obj
         # handle outside above except (on KeyError) so do not have unfriendly "exception within except" backtrace
         if not handled:
             if marker == ARRAY_START:
-                value = __decode_array(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys)
+                value = __decode_array(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys, errors)
             elif marker == OBJECT_START:
-                value = __decode_object(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys)
+                value = __decode_object(fp_read, no_bytes, object_hook, object_pairs_hook, intern_object_keys, errors)
             else:
                 raise DecoderException('Invalid marker within array')
 
@@ -312,7 +316,7 @@ def __object_hook_noop(obj):
     return obj
 
 
-def load(fp, no_bytes=False, object_hook=None, object_pairs_hook=None, intern_object_keys=False):
+def load(fp, no_bytes=False, object_hook=None, object_pairs_hook=None, intern_object_keys=False, errors='strict'):
     """Decodes and returns UBJSON from the given file-like object
 
     Args:
@@ -378,21 +382,21 @@ def load(fp, no_bytes=False, object_hook=None, object_pairs_hook=None, intern_ob
     marker = fp_read(1)
     try:
         try:
-            return __METHOD_MAP[marker](fp_read, marker)
+            return __METHOD_MAP[marker](fp_read, marker, errors)
         except KeyError:
             pass
         if marker == ARRAY_START:
-            return __decode_array(fp_read, bool(no_bytes), object_hook, object_pairs_hook, intern_object_keys)
+            return __decode_array(fp_read, bool(no_bytes), object_hook, object_pairs_hook, intern_object_keys, errors)
         if marker == OBJECT_START:
-            return __decode_object(fp_read, bool(no_bytes), object_hook, object_pairs_hook, intern_object_keys)
+            return __decode_object(fp_read, bool(no_bytes), object_hook, object_pairs_hook, intern_object_keys, errors)
         raise DecoderException('Invalid marker')
     except DecoderException as ex:
         raise_from(DecoderException(ex.args[0], position=(fp.tell() if hasattr(fp, 'tell') else None)), ex)
 
 
-def loadb(chars, no_bytes=False, object_hook=None, object_pairs_hook=None, intern_object_keys=False):
+def loadb(chars, no_bytes=False, object_hook=None, object_pairs_hook=None, intern_object_keys=False, errors='strict'):
     """Decodes and returns UBJSON from the given bytes or bytesarray object. See
        load() for available arguments."""
     with BytesIO(chars) as fp:
         return load(fp, no_bytes=no_bytes, object_hook=object_hook, object_pairs_hook=object_pairs_hook,
-                    intern_object_keys=intern_object_keys)
+                    intern_object_keys=intern_object_keys, errors=errors)


### PR DESCRIPTION
# Summary

This was inspired by my work with a [slippi replay file](https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md) (attached). The replay file contained a string with invalid utf-8 data. I would like to be able to parse this replay file.

# Changes

I updated both the C and Python code and added some new test cases for handling invalid string data. Note that I did *not* update the encode functionality.

# Tests

All tests still pass (except the recursion test, which I disabled locally for testing):

```bash
$ ./coverage_test.sh

Removing _ubjson.cpython-313-x86_64-linux-gnu.so
Removing build/
running build_ext
building '_ubjson' extension
creating build/temp.linux-x86_64-cpython-313/src
gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -coverage -fPIC -I/usr/include/python3.13 -c src/_ubjson.c -o build/temp.linux-x86_64-cpython-313/src/_ubjson.o -std=c99
gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -coverage -fPIC -I/usr/include/python3.13 -c src/decoder.c -o build/temp.linux-x86_64-cpython-313/src/decoder.o -std=c99
gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -coverage -fPIC -I/usr/include/python3.13 -c src/encoder.c -o build/temp.linux-x86_64-cpython-313/src/encoder.o -std=c99
gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -coverage -fPIC -I/usr/include/python3.13 -c src/python_funcs.c -o build/temp.linux-x86_64-cpython-313/src/python_funcs.o -std=c99
gcc -shared -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -coverage build/temp.linux-x86_64-cpython-313/src/_ubjson.o build/temp.linux-x86_64-cpython-313/src/decoder.o build/temp.linux-x86_64-cpython-313/src/encoder.o build/temp.linux-x86_64-cpython-313/src/python_funcs.o -L/usr/lib -o /home/davis/files/programming/python/py-ubjson/_ubjson.cpython-313-x86_64-linux-gnu.so
test_array (test.TestEncodeDecodeFp.test_array) ... ok
test_array_fixed (test.TestEncodeDecodeFp.test_array_fixed) ... ok
test_array_noop (test.TestEncodeDecodeFp.test_array_noop) ... ok
test_bool (test.TestEncodeDecodeFp.test_bool) ... ok
test_bytes (test.TestEncodeDecodeFp.test_bytes) ... ok
test_char (test.TestEncodeDecodeFp.test_char) ... ok
test_circular (test.TestEncodeDecodeFp.test_circular) ... ok
test_decode_exception_position (test.TestEncodeDecodeFp.test_decode_exception_position) ... ok
test_decode_object_hook (test.TestEncodeDecodeFp.test_decode_object_hook) ... ok
test_decoder_fuzz (test.TestEncodeDecodeFp.test_decoder_fuzz) ... ok
test_encode_default (test.TestEncodeDecodeFp.test_encode_default) ... ok
test_float (test.TestEncodeDecodeFp.test_float) ... ok
test_fp (test.TestEncodeDecodeFp.test_fp) ... ok
test_high_precision (test.TestEncodeDecodeFp.test_high_precision) ... ok
test_int (test.TestEncodeDecodeFp.test_int) ... ok
test_intern_object_keys (test.TestEncodeDecodeFp.test_intern_object_keys) ... ok
test_invalid_data (test.TestEncodeDecodeFp.test_invalid_data) ... ok
test_invalid_fp_dump (test.TestEncodeDecodeFp.test_invalid_fp_dump) ... ok
test_invalid_fp_load (test.TestEncodeDecodeFp.test_invalid_fp_load) ... ok
test_invalid_marker (test.TestEncodeDecodeFp.test_invalid_marker) ... ok
test_no_data (test.TestEncodeDecodeFp.test_no_data) ... ok
test_null (test.TestEncodeDecodeFp.test_null) ... ok
test_object (test.TestEncodeDecodeFp.test_object) ... ok
test_object_fixed (test.TestEncodeDecodeFp.test_object_fixed) ... ok
test_object_invalid (test.TestEncodeDecodeFp.test_object_invalid) ... ok
test_object_noop (test.TestEncodeDecodeFp.test_object_noop) ... ok
test_string (test.TestEncodeDecodeFp.test_string) ... ok
test_trailing_input (test.TestEncodeDecodeFp.test_trailing_input) ... ok
test_unencodable (test.TestEncodeDecodeFp.test_unencodable) ... ok
test_array (test.TestEncodeDecodeFpExt.test_array) ... ok
test_array_fixed (test.TestEncodeDecodeFpExt.test_array_fixed) ... ok
test_array_noop (test.TestEncodeDecodeFpExt.test_array_noop) ... ok
test_bool (test.TestEncodeDecodeFpExt.test_bool) ... ok
test_bytes (test.TestEncodeDecodeFpExt.test_bytes) ... ok
test_char (test.TestEncodeDecodeFpExt.test_char) ... ok
test_circular (test.TestEncodeDecodeFpExt.test_circular) ... ok
test_decode_exception_position (test.TestEncodeDecodeFpExt.test_decode_exception_position) ... ok
test_decode_object_hook (test.TestEncodeDecodeFpExt.test_decode_object_hook) ... ok
test_decoder_fuzz (test.TestEncodeDecodeFpExt.test_decoder_fuzz) ... ok
test_encode_default (test.TestEncodeDecodeFpExt.test_encode_default) ... ok
test_float (test.TestEncodeDecodeFpExt.test_float) ... ok
test_fp (test.TestEncodeDecodeFpExt.test_fp) ... ok
test_fp_buffer (test.TestEncodeDecodeFpExt.test_fp_buffer) ... ok
test_fp_callable_incomplete (test.TestEncodeDecodeFpExt.test_fp_callable_incomplete) ... ok
test_fp_multi (test.TestEncodeDecodeFpExt.test_fp_multi) ... ok
test_fp_seek_invalid (test.TestEncodeDecodeFpExt.test_fp_seek_invalid) ... ok
test_high_precision (test.TestEncodeDecodeFpExt.test_high_precision) ... ok
test_int (test.TestEncodeDecodeFpExt.test_int) ... ok
test_intern_object_keys (test.TestEncodeDecodeFpExt.test_intern_object_keys) ... ok
test_invalid_data (test.TestEncodeDecodeFpExt.test_invalid_data) ... ok
test_invalid_fp_dump (test.TestEncodeDecodeFpExt.test_invalid_fp_dump) ... ok
test_invalid_fp_load (test.TestEncodeDecodeFpExt.test_invalid_fp_load) ... ok
test_invalid_marker (test.TestEncodeDecodeFpExt.test_invalid_marker) ... ok
test_no_data (test.TestEncodeDecodeFpExt.test_no_data) ... ok
test_null (test.TestEncodeDecodeFpExt.test_null) ... ok
test_object (test.TestEncodeDecodeFpExt.test_object) ... ok
test_object_fixed (test.TestEncodeDecodeFpExt.test_object_fixed) ... ok
test_object_invalid (test.TestEncodeDecodeFpExt.test_object_invalid) ... ok
test_object_noop (test.TestEncodeDecodeFpExt.test_object_noop) ... ok
test_string (test.TestEncodeDecodeFpExt.test_string) ... ok
test_trailing_input (test.TestEncodeDecodeFpExt.test_trailing_input) ... ok
test_unencodable (test.TestEncodeDecodeFpExt.test_unencodable) ... ok
test_array (test.TestEncodeDecodePlain.test_array) ... ok
test_array_fixed (test.TestEncodeDecodePlain.test_array_fixed) ... ok
test_array_noop (test.TestEncodeDecodePlain.test_array_noop) ... ok
test_bool (test.TestEncodeDecodePlain.test_bool) ... ok
test_bytes (test.TestEncodeDecodePlain.test_bytes) ... ok
test_char (test.TestEncodeDecodePlain.test_char) ... ok
test_circular (test.TestEncodeDecodePlain.test_circular) ... ok
test_decode_object_hook (test.TestEncodeDecodePlain.test_decode_object_hook) ... ok
test_decoder_fuzz (test.TestEncodeDecodePlain.test_decoder_fuzz) ... ok
test_encode_default (test.TestEncodeDecodePlain.test_encode_default) ... ok
test_float (test.TestEncodeDecodePlain.test_float) ... ok
test_high_precision (test.TestEncodeDecodePlain.test_high_precision) ... ok
test_int (test.TestEncodeDecodePlain.test_int) ... ok
test_intern_object_keys (test.TestEncodeDecodePlain.test_intern_object_keys) ... ok
test_invalid_data (test.TestEncodeDecodePlain.test_invalid_data) ... ok
test_invalid_marker (test.TestEncodeDecodePlain.test_invalid_marker) ... ok
test_no_data (test.TestEncodeDecodePlain.test_no_data) ... ok
test_null (test.TestEncodeDecodePlain.test_null) ... ok
test_object (test.TestEncodeDecodePlain.test_object) ... ok
test_object_fixed (test.TestEncodeDecodePlain.test_object_fixed) ... ok
test_object_invalid (test.TestEncodeDecodePlain.test_object_invalid) ... ok
test_object_noop (test.TestEncodeDecodePlain.test_object_noop) ... ok
test_string (test.TestEncodeDecodePlain.test_string) ... ok
test_trailing_input (test.TestEncodeDecodePlain.test_trailing_input) ... ok
test_unencodable (test.TestEncodeDecodePlain.test_unencodable) ... ok
test_array (test.TestEncodeDecodePlainExt.test_array) ... ok
test_array_fixed (test.TestEncodeDecodePlainExt.test_array_fixed) ... ok
test_array_noop (test.TestEncodeDecodePlainExt.test_array_noop) ... ok
test_bool (test.TestEncodeDecodePlainExt.test_bool) ... ok
test_bytes (test.TestEncodeDecodePlainExt.test_bytes) ... ok
test_char (test.TestEncodeDecodePlainExt.test_char) ... ok
test_circular (test.TestEncodeDecodePlainExt.test_circular) ... ok
test_decode_object_hook (test.TestEncodeDecodePlainExt.test_decode_object_hook) ... ok
test_decoder_fuzz (test.TestEncodeDecodePlainExt.test_decoder_fuzz) ... ok
test_encode_default (test.TestEncodeDecodePlainExt.test_encode_default) ... ok
test_float (test.TestEncodeDecodePlainExt.test_float) ... ok
test_high_precision (test.TestEncodeDecodePlainExt.test_high_precision) ... ok
test_int (test.TestEncodeDecodePlainExt.test_int) ... ok
test_intern_object_keys (test.TestEncodeDecodePlainExt.test_intern_object_keys) ... ok
test_invalid_data (test.TestEncodeDecodePlainExt.test_invalid_data) ... ok
test_invalid_marker (test.TestEncodeDecodePlainExt.test_invalid_marker) ... ok
test_no_data (test.TestEncodeDecodePlainExt.test_no_data) ... ok
test_null (test.TestEncodeDecodePlainExt.test_null) ... ok
test_object (test.TestEncodeDecodePlainExt.test_object) ... ok
test_object_fixed (test.TestEncodeDecodePlainExt.test_object_fixed) ... ok
test_object_invalid (test.TestEncodeDecodePlainExt.test_object_invalid) ... ok
test_object_noop (test.TestEncodeDecodePlainExt.test_object_noop) ... ok
test_string (test.TestEncodeDecodePlainExt.test_string) ... ok
test_trailing_input (test.TestEncodeDecodePlainExt.test_trailing_input) ... ok
test_unencodable (test.TestEncodeDecodePlainExt.test_unencodable) ... ok

----------------------------------------------------------------------
Ran 112 tests in 7.767s

OK
Wrote HTML report to coverage/python/index.html
Capturing coverage data from .
geninfo cmd: '/usr/bin/geninfo . --toolname lcov --output-filename /tmp/ubjson-coverage.info.pre'
Found gcov version: 14.2.1
Using intermediate gcov format
Recording 'internal' directories:
	/home/davis/files/programming/python/py-ubjson
	.
Writing temporary data to /tmp/geninfo_dat2HzG
Scanning . for .gcda files ...
Found 4 data files in .
using: chunkSize: 1, nchunks:4, intervalLength:0
lcov: WARNING: using JSON module "JSON::PP" - which is much slower than some alternatives.  Consider installing one of JSON::XS or Cpanel::JSON::XS
lcov: WARNING: (inconsistent) /usr/include/python3.13/object.h:949: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
	(use "lcov --ignore-errors inconsistent,inconsistent ..." to suppress this warning)
Finished processing 4 GCDA files
Apply filtering..
Finished filter file processing
Finished .info-file creation
Summary coverage rate:
  source files: 10
  lines.......: 80.6% (994 of 1234 lines)
  functions...: 100.0% (54 of 54 functions)
Message summary:
  1 warning message:
    inconsistent: 1
Excluding /usr/include/bits/string_fortified.h
Excluding /usr/include/python3.13/cpython/bytearrayobject.h
Excluding /usr/include/python3.13/cpython/bytesobject.h
Excluding /usr/include/python3.13/cpython/listobject.h
Excluding /usr/include/python3.13/cpython/tupleobject.h
Excluding /usr/include/python3.13/object.h
Removed 6 files
Writing data to /tmp/ubjson-coverage.info.pre2
Summary coverage rate:
  source files: 4
  lines.......: 79.6% (934 of 1174 lines)
  functions...: 100.0% (53 of 53 functions)
Message summary:
  no messages were reported
Excluding /home/davis/files/programming/python/py-ubjson/src/python_funcs.c
Removed 1 files
Writing data to /tmp/ubjson-coverage.info
Summary coverage rate:
  source files: 3
  lines.......: 93.5% (882 of 943 lines)
  functions...: 100.0% (48 of 48 functions)
Message summary:
  no messages were reported
Reading tracefile /tmp/ubjson-coverage.info.
Found 3 entries.
Found common filename prefix "/home/davis/files/programming/python/py-ubjson"
Generating output.
Processing file src/decoder.c
  lines=513 hit=488 functions=24 hit=24
Processing file src/_ubjson.c
  lines=107 hit=98 functions=6 hit=6
Processing file src/encoder.c
  lines=323 hit=296 functions=18 hit=18
Overall coverage rate:
  source files: 3
  lines.......: 93.5% (882 of 943 lines)
  functions...: 100.0% (48 of 48 functions)
Message summary:
  no messages were reported

For coverage results see index.html in coverage sub-directories.

```

Additionally, the file that I couldn't parse before is now parsable!

```python
>>> import ubjson
>>> with open("test.slp", "rb") as f:
...     ubjson.load(f)
...     
Traceback (most recent call last):
  File "<python-input-14>", line 2, in <module>
    ubjson.load(f)
    ~~~~~~~~~~~^^^
ubjson.decoder.DecoderException: ('Failed to decode utf8: string (at byte 2655127)', 2655127)
>>> 
>>> with open("test.slp", "rb") as f:
...     ubjson.load(f, errors='replace')
# ...
# 'consoleNick': 'Frankhuize\n\ufff7\uffff뽯\uffff���\uffff�', 'players': {}, 'playedOn': 'nintendont'}}
# ^ The problematic data
```

# Attachments

* [coverage.zip](https://github.com/user-attachments/files/19405149/coverage.zip): Code coverage results
* [test_slp.zip](https://github.com/user-attachments/files/19405150/test_slp.zip): The problematic slippi file, which wasn't being parsed properly before